### PR TITLE
Fix a typo in the places list

### DIFF
--- a/places.csv
+++ b/places.csv
@@ -733,7 +733,7 @@ id,area,county,parish
 "skvr_6590","r","Tverin alue","Veśśi"
 "skvr_6595","r","Tverin alue","Voločka"
 "skvr_9190","r","Tverin alue","Tveri"
-"skvr_6600","r","Novgorodin  alue","Njebelitsa"
+"skvr_6600","r","Novgorodin alue","Njebelitsa"
 "skvr_9191","r","Novgorodin alue","Novgorodin alue"
 "skvr_6710","x","Metsäsuomalaisten alue","Åsnes Finnskog"
 "skvr_6715","x","Metsäsuomalaisten alue","Hof Finnskog"


### PR DESCRIPTION
Double space in the county name causes problems in automatic processing.